### PR TITLE
typo fix: kebab-case to camel-case

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To extend that module, you'd do something like this:
 ```javascript
 const extended = myModule.extend({
   callout: {
-    text-decoration: "underline"
+    textDecoration: "underline"
   }
 })
 


### PR DESCRIPTION
The property was in kebab-case, but it should have probably been the JS version and thus camelCase