### PR TITLE
Workaround for bug in Safari 16.4

### DIFF
--- a/src/style-mod.js
+++ b/src/style-mod.js
@@ -86,11 +86,11 @@ class StyleSet {
   constructor(root) {
     if (!root.head && root.adoptedStyleSheets && typeof CSSStyleSheet != "undefined") {
       if (adoptedSet) {
-        root.adoptedStyleSheets = [adoptedSet.sheet].concat(root.adoptedStyleSheets)
+        root.adoptedStyleSheets = [adoptedSet.sheet, ...root.adoptedStyleSheets]
         return root[SET] = adoptedSet
       }
       this.sheet = new CSSStyleSheet
-      root.adoptedStyleSheets = [this.sheet].concat(root.adoptedStyleSheets)
+      root.adoptedStyleSheets = [this.sheet, ...root.adoptedStyleSheets]
       adoptedSet = this
     } else {
       this.styleTag = (root.ownerDocument || root).createElement("style")


### PR DESCRIPTION
In Safari 16.4, `[sheet].concat(root.adoptedStyleSheets)` returns `[CSSStyleSheet, []]` instead of `[CSSStyleSheet]`.
This results in a `TypeError` when trying to assign to `root.adoptedStyleSheets`.

When using the spread syntax it does give the wanted result.

I will create an issue for this in the webkit bug tracker too.
