### PR TITLE
fix: Cannot read properties of undefined (reading 'length')

### DIFF
--- a/src/style-mod.js
+++ b/src/style-mod.js
@@ -119,7 +119,10 @@ class StyleSet {
         if (sheet) for (let k = 0; k < mod.rules.length; k++)
           sheet.insertRule(mod.rules[k], pos++)
       } else {
-        while (j < index) pos += this.modules[j++].rules.length
+        while (j < index) {
+          let rules = this.modules[j++].rules;
+          if (rules) pos += rules.length;
+        }
         pos += mod.rules.length
         j++
       }


### PR DESCRIPTION
Hello,
It seems like `this.modules[j++].rules` on line 122 of style.mod.js can be undefined sometimes. At least it happened here when I am using Codemirror that is inside [plugin-split-editing of milkdown](https://github.com/enpitsuLin/milkdown-lab/tree/master/packages/plugin-split-editing).

Anyway. It should be protected to deal with such case.
This PR is a proposed fix.
Let me know if it can be merged soon and a new version tagged and released. thanks.