### PR TITLE
Fix missing types when resolving cjs with require

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "exports": {
     "import": "./src/style-mod.js",
+    "types": "./src/style-mod.d.ts",
     "require": "./dist/style-mod.cjs"
   },
   "module": "src/style-mod.js",


### PR DESCRIPTION
When typescript resolves types with cjs mode and require it will look for require in conditional exports but won't find types, and will ignore type field in the parent, leading to missing types.

I have this problem on `node@20.16.0`, `typescript@5.9.3`, in a lib using `@codemirror/view@6.38.6`.
Adding types to the export in package.json fixes it.