### PR TITLE
chore: exclude test directory from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 .tern-*
+test


### PR DESCRIPTION
The `test/` directory is currently included in the published npm package but is not needed by consumers.

This PR adds `test` to the existing `.npmignore` to exclude test files from the tarball, reducing the package size.

**Before:**
```
npm notice 2.8kB test/test-style-mod.js
```

**After:**
Test files no longer shipped.